### PR TITLE
Various tracker module features

### DIFF
--- a/source/audioformats/pocketmod.d
+++ b/source/audioformats/pocketmod.d
@@ -892,6 +892,14 @@ int pocketmod_render(pocketmod_context *c, void *buffer, int buffer_size)
     return samples_rendered * POCKETMOD_SAMPLE_SIZE;
 }
 
+void pocketmod_seek(pocketmod_context* c, ubyte pattern, ubyte row, ushort tick) {
+    // NOTE: This is untested.
+    c.line = row;
+    c.pattern = pattern;
+    c.tick = tick;
+    c.sample = 0;
+}
+
 int pocketmod_loop_count(pocketmod_context *c)
 {
     return c.loop_count;

--- a/source/audioformats/stream.d
+++ b/source/audioformats/stream.d
@@ -611,7 +611,7 @@ public: // This is also part of the public API
 
     /// Length. Returns the amount of patterns in the module
     /// Formats that support this: MOD, XM
-    int countModulePattern() {
+    int countModulePatterns() {
         assert(_io && (_io.read !is null) );
         final switch(_format) with (AudioFileFormat)
         {
@@ -741,7 +741,7 @@ public: // This is also part of the public API
                 pocketmod_seek(_modDecoder, pattern, row, 0);
                 return true;
             case xm:
-            
+
                 xm_seek(_xmDecoder, cast(ubyte)pattern, cast(ubyte)row, 0);
                 return true;
 

--- a/source/audioformats/stream.d
+++ b/source/audioformats/stream.d
@@ -629,6 +629,26 @@ public: // This is also part of the public API
         }
     }
 
+    /// Length. Returns the amount of PLAYED patterns in the module
+    /// Formats that support this: MOD, XM
+    int getModuleLength() {
+        assert(_io && (_io.read !is null) );
+        final switch(_format) with (AudioFileFormat)
+        {
+            case mp3: 
+            case flac:
+            case ogg:
+            case opus:
+            case wav:
+            case unknown:
+                assert(false);
+            case mod:
+                return _modDecoder.length;
+            case xm:
+                return xm_get_module_length(_xmDecoder);
+        }
+    }
+
     /// Tell. Returns amount of rows in a pattern.
     /// Formats that support this: MOD, XM
     int rowsInPattern(int pattern) {


### PR DESCRIPTION
This is a small untested change that adds the various tracker seeking/telling features I wanted in #15, it's still incomplete but supports most of it.

Only need to figure out how to calculate the sample length of an XM pattern, then it's fully done.

Currently here's how support looks
| Feature                    | XM | MOD | Description                                                                            |
|----------------------------|----|-----|----------------------------------------------------------------------------------------|
| countModulePatterns        | X  | X   | Gets total count of patterns in module (whether they're played or not)                 |
| getModuleLength            | X  | X   | Gets how many patterns that are in the order list, amount of patterns actually played. |
| rowsInPattern              | X  | X   | Gets how many rows that are in a specific pattern.                                     |
| tellModulePattern          | X  | X   | Gets the id of the current pattern being played.                                       |
| tellModuleRow              | X  | X   | Gets the current row being played.                                                     |
| samplesRemainingInPattern  |    | X*  | Gets the amount of samples left in the current playing pattern.                        |
| seekPosition (row+pattern) | X  | X*  | Seeks to a specific row and pattern, setting tick to 0.                                |

\* = Untested

I've taken some reference from http://lclevy.free.fr/mo3/mod.txt when it comes to implementing samplesRemainingInPattern for MOD files.