### PR TITLE
Fix framesRemainingInPattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ https://github.com/AuburnSounds/audio-formats/blob/master/examples/transcode/sou
 | FLAC  | Yes        | No       | Sample          |
 | OPUS  | Yes (LGPL) | No       | Coarse          |
 | OGG   | Yes        | No       | Sample          |
-| MOD   | Yes        | No       | No              |
-| XM    | Yes        | No       | No              |
+| MOD   | Yes        | No       | Pattern+Row     |
+| XM    | Yes        | No       | Pattern+Row     |
 
 
 Some of these decoders were originally translated by Ketmar, who did the heavy-lifting.
@@ -40,7 +40,13 @@ Some of these decoders were originally translated by Ketmar, who did the heavy-l
 - LGPL v2.1 with OPUS decoding.
 (use DUB subconfigurations) to choose, default is boost.
 
+# Extras
+The following version identifiers can be used to enable/disable decoder level features  
+| Version Identifier | Feature                                                       |
+|--------------------|---------------------------------------------------------------|
+| AF_LINEAR          | Use linear sampling for MOD modules instead of Amiga sampling |
+|                    |                                                               |
 
 # Bugs
 
-- OGG decoding doesn't work, the sound is unusable.
+- framesRemainingInPattern is unimplemented for XM currently.

--- a/source/audioformats/libxm.d
+++ b/source/audioformats/libxm.d
@@ -932,6 +932,11 @@ int xm_create_context_safe(xm_context_t** ctxp, const char* moddata, size_t modd
 	return 0;
 }
 
+int xm_count_remaining_samples(xm_context_t* context) {
+    // TODO: implement
+    return 0;
+}
+
 void xm_free_context(xm_context_t* context) {
 	free(context);
 }

--- a/source/audioformats/pocketmod.d
+++ b/source/audioformats/pocketmod.d
@@ -288,7 +288,8 @@ void _pocketmod_volume_slide(_pocketmod_chan *ch, int param)
 }
 
 /**
-    Returns where there is a pattern break in the current playing pattern
+    Returns the amount of remaining (mono) samples/frames in the 
+    currently playing pattern.
 */
 int pocketmod_count_remaining_samples(pocketmod_context *c) {
     ubyte[4]* data;

--- a/source/audioformats/pocketmod.d
+++ b/source/audioformats/pocketmod.d
@@ -27,8 +27,6 @@ SOFTWARE.
 // Translated to D by Guillaume Piolat Copyright 2021.
 module audioformats.pocketmod;
 
-
-version = POCKETMOD_NO_INTERPOLATION; // sounds better to me, linear interp is darker
 nothrow:
 @nogc:
 
@@ -692,15 +690,12 @@ void _pocketmod_render_channel(pocketmod_context *c,
         for (i = 0; i < num; i++) 
         {
             int x0 = cast(int)(chan.position);
-            version(POCKETMOD_NO_INTERPOLATION)
-            {
-                float s = sample.data[x0];
-            }
-            else
-            {
+            version(AF_LINEAR) {
                 int x1 = x0 + 1 - loop_length * (x0 + 1 >= loop_end);
                 float t = chan.position - x0;
                 float s = (1.0f - t) * sample.data[x0] + t * sample.data[x1];
+            } else {
+                float s = sample.data[x0];
             }
 
             chan.position += chan.increment;

--- a/source/audioformats/pocketmod.d
+++ b/source/audioformats/pocketmod.d
@@ -302,7 +302,6 @@ int pocketmod_pattern_break(pocketmod_context *c) {
         data = cast(ubyte[4]*) (c.patterns + pos);
         for (i = 0; i < c.num_channels; i++) 
         {
-
             /* Decode columns */
             int effect = ((data[i][2] & 0x0f) << 8) | data[i][3];
 
@@ -312,7 +311,7 @@ int pocketmod_pattern_break(pocketmod_context *c) {
             ch.param = (effect >> 8) != 0xe ? (effect & 0xff) : (effect & 0x0f);
             switch (ch.effect) {
                 /* Dxy: Pattern break */
-                case 0xD: return line;
+                case 0xD: return line+1; // Our pattern jumps *after* decoding the data where the break is on.
                 default: break;
             }
         }

--- a/source/audioformats/stream.d
+++ b/source/audioformats/stream.d
@@ -804,22 +804,9 @@ public: // This is also part of the public API
                 assert(false);
 
             case mod:
-
-                // According to http://lclevy.free.fr/mo3/mod.txt
-                // there's 64 lines (aka rows) per pattern normally
-                // EXCEPT if there's a pattern break effect.
-                // If one is found we skip.
-                int pbreak = pocketmod_pattern_break(_modDecoder);
-                int lineCount = pbreak == -1 ? 64 : pbreak;
-
-                // NOTE: This is calculated from a single channel
-                // As such do not divide by _numChannels as the unit
-                // is already in frames.
-                int samplesPerLine = cast(int)(cast(float)_modDecoder.ticks_per_line*_modDecoder.samples_per_tick);
-                int frames = (lineCount-_modDecoder.line)*samplesPerLine;
-                return frames;
-            
+                return pocketmod_count_remaining_samples(_modDecoder);
             case xm:
+
                 return 0; // NOT IMPLEMENTED
         }
     }

--- a/source/audioformats/stream.d
+++ b/source/audioformats/stream.d
@@ -806,8 +806,7 @@ public: // This is also part of the public API
             case mod:
                 return pocketmod_count_remaining_samples(_modDecoder);
             case xm:
-
-                return 0; // NOT IMPLEMENTED
+                return xm_count_remaining_samples(_xmDecoder);
         }
     }
 

--- a/source/audioformats/stream.d
+++ b/source/audioformats/stream.d
@@ -806,14 +806,17 @@ public: // This is also part of the public API
             case mod:
 
                 // According to http://lclevy.free.fr/mo3/mod.txt
-                // there's 64 lines (aka rows) per pattern.
-                int rows = 64;
+                // there's 64 lines (aka rows) per pattern normally
+                // EXCEPT if there's a pattern break effect.
+                // If one is found we skip.
+                int pbreak = pocketmod_pattern_break(_modDecoder);
+                int lineCount = pbreak == -1 ? 64 : pbreak;
 
                 // NOTE: This is calculated from a single channel
                 // As such do not divide by _numChannels as the unit
                 // is already in frames.
                 int samplesPerLine = cast(int)(cast(float)_modDecoder.ticks_per_line*_modDecoder.samples_per_tick);
-                int frames = (rows-_modDecoder.line)*samplesPerLine;
+                int frames = (lineCount-_modDecoder.line)*samplesPerLine;
                 return frames;
             
             case xm:

--- a/source/audioformats/stream.d
+++ b/source/audioformats/stream.d
@@ -809,10 +809,12 @@ public: // This is also part of the public API
                 // there's 64 lines (aka rows) per pattern.
                 int rows = 64;
 
-                // NOTE: This is untested.
+                // NOTE: This is calculated from a single channel
+                // As such do not divide by _numChannels as the unit
+                // is already in frames.
                 int samplesPerLine = cast(int)(cast(float)_modDecoder.ticks_per_line*_modDecoder.samples_per_tick);
-                int samples = (rows-_modDecoder.line)*samplesPerLine;
-                return samples / _numChannels;
+                int frames = (rows-_modDecoder.line)*samplesPerLine;
+                return frames;
             
             case xm:
                 return 0; // NOT IMPLEMENTED


### PR DESCRIPTION
This PR fixes framesRemainingInPattern for the MOD format by:
Fixing the data being cut off by a division (the length is effectively already based of one frame)
Support detecting MOD pattern breaks and adjusting length according to those.